### PR TITLE
Section 1.2: Skills & Recall Figures (Questions 1-5)

### DIFF
--- a/source/prefcode-concave-quad.ptx
+++ b/source/prefcode-concave-quad.ptx
@@ -4,14 +4,14 @@
   <coordinates bbox="(-6,-1,6,8)">
 
     <!-- Arrowhead concave quadrilateral -->
-    <polygon points="((-3,1), (0,7), (3,1), (0,2.5))" closed="yes" fill="none" stroke="black">
+    <polygon points="((-3,1), (0,7), (3,1), (0,2.5))" closed="yes" fill="none" stroke="black" thickness="1.5">
     </polygon>
 
     <!-- Points -->
-    <point name="A" p="(-2.9,1.1)" fill="green"/>
-    <point name="B" p="(0,7)" fill="green"/>
-    <point name="C" p="(2.9,1.1)" fill="green"/>
-    <point name="D" p="(0,2.5)" fill="green"/>
+    <point name="A" p="(-2.9,1.1)" fill="white" thickness="1.5"/>
+    <point name="B" p="(0,7)" fill="white" thickness="1.5"/>
+    <point name="C" p="(2.9,1.1)" fill="white" thickness="1.5"/>
+    <point name="D" p="(0,2.5)" fill="white" thickness="1.5"/>
 
     <!-- Optional labels -->
     <label p="(-2.9,0.7)" scale="0.8"><m>\scriptsize \textbf{A}</m></label>

--- a/source/prefcode-concave-quad.ptx
+++ b/source/prefcode-concave-quad.ptx
@@ -4,8 +4,7 @@
   <coordinates bbox="(-6,-1,6,8)">
 
     <!-- Arrowhead concave quadrilateral -->
-    <polygon points="((-3,1), (0,7), (3,1), (0,2.5))" closed="yes" fill="#B2D8B2">
-      <style>stroke:black; stroke-width:2;</style>
+    <polygon points="((-3,1), (0,7), (3,1), (0,2.5))" closed="yes" fill="none" stroke="black">
     </polygon>
 
     <!-- Points -->

--- a/source/prefcode-equi-rhom60.ptx
+++ b/source/prefcode-equi-rhom60.ptx
@@ -2,13 +2,13 @@
 
 <diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
   <coordinates bbox="(-4,-1,7,6)">
-    <polygon points="((-1.5,2),(5.3,2),(3,5.2),(-3,5.2))" closed="yes" fill="none" size="2" stroke="black">
+    <polygon points="((-1.5,2),(5.3,2),(3,5.2),(-3,5.2))" closed="yes" fill="none" size="2" stroke="black" thickness="1.5">
     </polygon>
 
-    <point name="A" p="(-3,5.2)" />
-    <point name="B" p="(3,5.2)" />
-    <point name="C" p="(5.3,2)" />
-    <point name="D" p="(-1.5,2)" />
+    <point name="A" p="(-3,5.2)" fill="white" thickness="1.5"/>
+    <point name="B" p="(3,5.2)" fill="white" thickness="1.5"/>
+    <point name="C" p="(5.3,2)" fill="white" thickness="1.5"/>
+    <point name="D" p="(-1.5,2)" fill="white" thickness="1.5"/>
 
     <label p="(-2.1,4.8)" scale="0.8"><m>\scriptsize \textbf{60°}</m></label>
     <label p="(2.6,4.8)" scale="0.8"><m>\scriptsize \textbf{120°}</m></label>

--- a/source/prefcode-equi-rhom60.ptx
+++ b/source/prefcode-equi-rhom60.ptx
@@ -2,8 +2,7 @@
 
 <diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
   <coordinates bbox="(-4,-1,7,6)">
-    <polygon points="((-1.5,2),(5.3,2),(3,5.2),(-3,5.2))" closed="yes" fill="pink" size="2">
-      <style>stroke:blue; stroke-width:2;</style>
+    <polygon points="((-1.5,2),(5.3,2),(3,5.2),(-3,5.2))" closed="yes" fill="none" size="2" stroke="black">
     </polygon>
 
     <point name="A" p="(-3,5.2)" />

--- a/source/prefcode-equiang-hexagon.ptx
+++ b/source/prefcode-equiang-hexagon.ptx
@@ -2,8 +2,8 @@
 
 <diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
     <coordinates bbox="(-3.5,-2.5,3.5,2.5)">
-      <polygon points="((-1,-2.598),(1,-2.598),(2.5,0),(1,2.598),(-1,2.598),(-2.5,0))" closed="yes" fill="plum" size="2">
-        <style>stroke:black; stroke-width:2;</style>
+      <polygon points="((-1,-2.598),(1,-2.598),(2.5,0),(1,2.598),(-1,2.598),(-2.5,0))" closed="yes" fill="none" size="2"
+        stroke="black" stroke-width="2">
       </polygon>
 
       <point name="A" p="(-1,-2.498)" fill = "lavender" />

--- a/source/prefcode-equiang-hexagon.ptx
+++ b/source/prefcode-equiang-hexagon.ptx
@@ -1,37 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
-    <coordinates bbox="(-3.5,-2.5,3.5,2.5)">
-      <polygon points="((-1,-2.598),(1,-2.598),(2.5,0),(1,2.598),(-1,2.598),(-2.5,0))" closed="yes" fill="none" size="2"
-        stroke="black" stroke-width="2">
-      </polygon>
+  <coordinates bbox="(-3.5,-3,3.5,3)">
+    
+    <polygon 
+      points="((-1,-2.598),(1,-2.598),(2.5,0),(1,2.598),(-1,2.598),(-2.5,0))" 
+      closed="yes" 
+      fill="none" 
+      stroke="black" 
+      stroke-width="2"
+      thickness="1.5"/>
 
-      <point name="A" p="(-1,-2.498)" fill = "lavender" />
-      <point name="B" p="(1,-2.498)" fill = "lavender" />
-      <point name="C" p="(2.5,0)" fill = "lavender" />
-      <point name="D" p="(1,2.498)" fill = "lavender" />
-      <point name="E" p="(-1,2.498)" fill = "lavender" />
-      <point name="F" p="(-2.5,0)" fill = "lavender"/>
+    <!-- Points -->
+    <point name="E" p="(-1,-2.598)" fill="white" thickness="1.5"/>
+    <point name="D" p="(1,-2.598)" fill="white" thickness="1.5"/>
+    <point name="C" p="(2.5,0)" fill="white" thickness="1.5"/>
+    <point name="B" p="(1,2.598)" fill="white" thickness="1.5"/>
+    <point name="A" p="(-1,2.598)" fill="white" thickness="1.5"/>
+    <point name="F" p="(-2.5,0)" fill="white" thickness="1.5"/>
 
-      <label p="(-0.7,-2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label> 
-      <label p="(0.8,-2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label> 
-      <label p="(2,0)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>   
-      <label p="(0.8,2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>   
-      <label p="(-0.7,2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>   
-      <label p="(-1.9,0)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>
+    <!-- Angle labels -->
+    <label p="(-0.7,-2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label> 
+    <label p="(0.8,-2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label> 
+    <label p="(2,0)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>   
+    <label p="(0.8,2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>   
+    <label p="(-0.7,2.2)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>   
+    <label p="(-1.9,0)" scale="0.7"><m>\scriptsize \textbf{120°}</m></label>
 
-      <label p="(-1.4,2.5)" scale="0.9"><m>\scriptsize \textbf{A}</m></label>
-      <label p="(1.4,2.5)" scale="0.9"><m>\scriptsize \textbf{B}</m></label>
-      <label p="(2.9,0)" scale="0.9"><m>\scriptsize \textbf{C}</m></label>
-      <label p="(1.4,-2.5)" scale="0.9"><m>\scriptsize \textbf{D}</m></label>
-      <label p="(-1.4,-2.5)" scale="0.9"><m>\scriptsize \textbf{E}</m></label>
-      <label p="(-2.8,0)" scale="0.9"><m>\scriptsize \textbf{F}</m></label>
+    <!-- Vertex labels -->
+    <label p="(-1.4,2.6)" scale="0.9"><m>\scriptsize \textbf{A}</m></label>
+    <label p="(1.4,2.6)" scale="0.9"><m>\scriptsize \textbf{B}</m></label>
+    <label p="(2.9,0)" scale="0.9"><m>\scriptsize \textbf{C}</m></label>
+    <label p="(1.4,-2.7)" scale="0.9"><m>\scriptsize \textbf{D}</m></label>
+    <label p="(-1.4,-2.7)" scale="0.9"><m>\scriptsize \textbf{E}</m></label>
+    <label p="(-2.9,0)" scale="0.9"><m>\scriptsize \textbf{F}</m></label>
 
-      <label p="(0,-2.6)" scale="0.8"><m>\scriptsize \textbf{1.5}</m></label>
-      <label p="(2, -1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
-      <label p="(2, 1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
-      <label p="(0, 2.6)" scale="0.8"><m>\scriptsize \textbf{1.5}</m></label>
-      <label p="(-2, 1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
-      <label p="(-2, -1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
-    </coordinates>
+    <!-- Side length labels -->
+    <label p="(0,-2.8)" scale="0.8"><m>\scriptsize \textbf{1.5}</m></label>
+    <label p="(2, -1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
+    <label p="(2, 1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
+    <label p="(0, 2.8)" scale="0.8"><m>\scriptsize \textbf{1.5}</m></label>
+    <label p="(-2, 1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
+    <label p="(-2, -1.3)" scale="0.8"><m>\scriptsize \textbf{3}</m></label>
+  </coordinates>
 </diagram>

--- a/source/prefcode-equiang-rectangle.ptx
+++ b/source/prefcode-equiang-rectangle.ptx
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
+  <coordinates bbox="(-4,-1,7,6)">
+    <polygon points="((-3,4),(6,4),(6,2),(-3,2))" closed="yes" fill="none" size="2" stroke="black" thickness="1.5">
+    </polygon>
+
+    <point name="A" p="(-3,4)" fill="white" thickness="1.5"/>
+    <point name="B" p="(6,4)" fill="white" thickness="1.5"/>
+    <point name="C" p="(6,2)" fill="white" thickness="1.5"/>
+    <point name="D" p="(-3,2)" fill="white" thickness="1.5"/>
+
+    <label p="(-2.3,3.7)" scale="0.8"><m>\scriptsize \textbf{90°}</m></label>
+    <label p="(5.5,3.7)" scale="0.8"><m>\scriptsize \textbf{90°}</m></label>
+    <label p="(5.5,2.3)" scale="0.8"><m>\scriptsize \textbf{90°}</m></label>
+    <label p="(-2.3,2.3)" scale="0.8"><m>\scriptsize \textbf{90°}</m></label>
+
+    <label p="(-3.5,4.3)" scale="0.8"><m>\scriptsize \textbf{A}</m></label>
+    <label p="(6.5,4.3)" scale="0.8"><m>\scriptsize \textbf{B}</m></label>
+    <label p="(6.5,1.7)" scale="0.8"><m>\scriptsize \textbf{C}</m></label>
+    <label p="(-3.5,1.7)" scale="0.8"><m>\scriptsize \textbf{D}</m></label>
+
+    <label p="(6.4,3)" scale="0.8"><m>\scriptsize \textbf{2}</m></label>
+    <label p="(1.5,4.3)" scale="0.8"><m>\scriptsize \textbf{5}</m></label>
+    <label p="(1.5,1.7)" scale="0.8"><m>\scriptsize \textbf{5}</m></label>
+    <label p="(-3.4,3)" scale="0.8"><m>\scriptsize \textbf{2}</m></label>
+  </coordinates>
+</diagram>

--- a/source/prefcode-isos-obtuse-tri.ptx
+++ b/source/prefcode-isos-obtuse-tri.ptx
@@ -2,8 +2,7 @@
 
 <diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
     <coordinates bbox="(-5,-5,5,5)">
-      <polygon points="((-4,0),(4,0),(0,2))" closed="yes" fill="skyblue" size="2">
-        <style>stroke:black; stroke-width:2;</style>
+      <polygon points="((-4,0),(4,0),(0,2))" closed="yes" fill="none" size="2" stroke="black">
       </polygon>
 
       <point name="A" p="(-4,0)" />

--- a/source/prefcode-isos-obtuse-tri.ptx
+++ b/source/prefcode-isos-obtuse-tri.ptx
@@ -2,15 +2,15 @@
 
 <diagram xmlns="https://prefigure.org" width="225" height="225" margins="10">
     <coordinates bbox="(-5,-5,5,5)">
-      <polygon points="((-4,0),(4,0),(0,2))" closed="yes" fill="none" size="2" stroke="black">
+      <polygon points="((-4,0),(4,0),(0,2))" closed="yes" fill="none" size="2" stroke="black" thickness="1.5">
       </polygon>
 
-      <point name="A" p="(-4,0)" />
-      <point name="B" p="(4,0)" />
-      <point name="C" p="(0,2)" />
+      <point name="A" p="(-4,0)" fill="white" thickness="1.5"/>
+      <point name="B" p="(4,0)" fill="white" thickness="1.5"/>
+      <point name="C" p="(0,2)" fill="white" thickness="1.5"/>
 
-      <label p="(-3,0.2)" scale="0.8"><m>\scriptsize \textbf{30°}</m></label>
-      <label p="(3,0.2)" scale="0.8"><m>\scriptsize \textbf{30°}</m></label>
+      <label p="(-2.8,0.25)" scale="0.8"><m>\scriptsize \textbf{30°}</m></label>
+      <label p="(2.8,0.25)" scale="0.8"><m>\scriptsize \textbf{30°}</m></label>
       <label p="(0.1,1.5)" scale="0.8"><m>\scriptsize \textbf{120°}</m></label>
 
       <label p="(-4.5,0)" scale="0.8"><m>\scriptsize \textbf{A}</m></label>

--- a/source/sec-intro-apply.ptx
+++ b/source/sec-intro-apply.ptx
@@ -1378,6 +1378,24 @@ format: www.psychologicalscience.org/observer/dweck-growth-mindsets-->
               A rectangle is equiangular but not necessarily equilateral.
             </p>
           </answer>
+          <solution>
+            <p>
+              <figure xml:id="fig-equiangular-rectangle-">
+                <caption>A sample rectangle <m>ABCD</m>.</caption>
+                <image>
+                  <prefigure xmlns="https://prefigure.org" label="pref-equiang-rectangle" 
+                    xml:id="pref-equiang-rectangle">
+                    <xi:include href="prefcode-equiang-rectangle.ptx" />
+                  </prefigure>
+                </image>
+              </figure>
+            </p>
+            <p>
+              A rectangle is classified as an equiangular quadrilateral because all its angles are congruent at 90 degrees.
+              However, a rectangle is not always equilateral because its sides are not necessarily the same length. In rectangle
+              <m>ABCD</m>, both these characteristics are evident.
+            </p>
+          </solution>
         </task>
       </exercise>
       <exercise>


### PR DESCRIPTION
**Section 1.2: Skills & Recall Questions 1-5**:

- Created various geometric figures including a triangle, rhombus, hexagon, concave quadrilateral, and rectangle.
- Designed and previewed these figures using PreFigure Playground software.
- For each figure, visual appearance remained consistent with fill="none" and thickness="1".
- Once figures were designed, their code was stored on GitHub.
- Storing the code made it possible to reference individual figures and include them for answers/solutions.

**Changes to Note for Figures:**
- No longer stored as .svg files.
- No longer filled with color (instead fill="none").
- Thickness is reduced from 2 down to 1.5.

